### PR TITLE
make DOM display say day instead of duration

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -115,7 +115,7 @@ const loadCards = (trips) => {
             <img src =${foundDestination.image} alt= ${foundDestination.alt}>
             destination: ${foundDestination.destination}<br>
             travelers: ${trip.travelers}<br>
-            duration: ${trip.duration}<br>
+            days: ${trip.duration}<br>
             date: ${trip.date}
         </div>
         `


### PR DESCRIPTION
edits one word, so that trip display says "days" instead of "duration"